### PR TITLE
Register AnnotationCompletor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     ],
     "require": {
         "php": "^7.3",
-        "phpactor/container": "^1.3.3",
-        "phpactor/completion-extension": "~0.2",
+        "phpactor/completion": "^0..4.3",
         "phpactor/worse-reflection-extension": "~0.2",
         "phpactor/source-code-filesystem-extension": "~0.1",
         "phpactor/reference-finder-extension": "^0.1.5"

--- a/lib/CompletionWorseExtension.php
+++ b/lib/CompletionWorseExtension.php
@@ -5,6 +5,7 @@ namespace Phpactor\Extension\CompletionWorse;
 use Phpactor\Completion\Bridge\TolerantParser\LimitingCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\ReferenceFinder\NameSearcherCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\SourceCodeFilesystem\ScfClassCompletor;
+use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\AnnotationCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\WorseClassAliasCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\WorseConstantCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\WorseConstructorCompletor;
@@ -79,6 +80,13 @@ class CompletionWorseExtension implements Extension
                     return $container->get($serviceId);
                 }, $container->get(self::SERVICE_COMPLETOR_MAP)),
                 $container->get('worse_reflection.tolerant_parser')
+            );
+        }, [ CompletionExtension::TAG_COMPLETOR => []]);
+
+        $container->register(AnnotationCompletor::class, function (Container $container) {
+            return new AnnotationCompletor(
+                $container->get(NameSearcher::class),
+                $container->get(WorseReflectionExtension::SERVICE_REFLECTOR)
             );
         }, [ CompletionExtension::TAG_COMPLETOR => []]);
 

--- a/lib/CompletionWorseExtension.php
+++ b/lib/CompletionWorseExtension.php
@@ -5,7 +5,7 @@ namespace Phpactor\Extension\CompletionWorse;
 use Phpactor\Completion\Bridge\TolerantParser\LimitingCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\ReferenceFinder\NameSearcherCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\SourceCodeFilesystem\ScfClassCompletor;
-use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\AnnotationCompletor;
+use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\DoctrineAnnotationCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\WorseClassAliasCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\WorseConstantCompletor;
 use Phpactor\Completion\Bridge\TolerantParser\WorseReflection\WorseConstructorCompletor;
@@ -83,8 +83,8 @@ class CompletionWorseExtension implements Extension
             );
         }, [ CompletionExtension::TAG_COMPLETOR => []]);
 
-        $container->register(AnnotationCompletor::class, function (Container $container) {
-            return new AnnotationCompletor(
+        $container->register(DoctrineAnnotationCompletor::class, function (Container $container) {
+            return new DoctrineAnnotationCompletor(
                 $container->get(NameSearcher::class),
                 $container->get(WorseReflectionExtension::SERVICE_REFLECTOR)
             );


### PR DESCRIPTION
Register the new completor intoduced by https://github.com/phpactor/completion/pull/32

I think the `phpactor/completion` is used from `phpactor/completion-extension`.
So I guess I would need to update the version of `phpactor/completio` in `phpactor/completion-extension` and update the version of `phpactor/completion-extension` in this package when the review will be done and accepted ?